### PR TITLE
Bumping version of libxmljs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "node": ">= 0.12.0"
     },
     "dependencies": {
-        "libxmljs": "^0.18.0",
+        "libxmljs": "^0.19.0",
         "lodash": "^3.10.1",
         "moment": "^2.17.1"
     },


### PR DESCRIPTION
This provides better compatibility with recent node versions (i.e. 13). Otherwise, installing blue-button fails when it tries to do libxmljs